### PR TITLE
CHANGE(kibana): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,12 @@ openio_kibana_elasticsearch_port:
 
 openio_kibana_elasticsearch_user: null
 openio_kibana_elasticsearch_pass: null
+
+openio_kibana_servicename: "kibana-{{ openio_kibana_serviceid }}"
+
+openio_kibana_sysconfig_dir: "/etc/oio/sds/{{ openio_kibana_namespace }}/{{ openio_kibana_servicename }}"
+openio_kibana_pid_directory: "/run/oio/sds/{{ openio_kibana_namespace }}"
+openio_kibana_log_dir: "/var/log/oio/sds/{{ openio_kibana_namespace }}/{{ openio_kibana_servicename }}"
+
+openio_kibana_url: "http://{{ openio_kibana_bind_address }}:{{ openio_kibana_bind_port }}"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,10 +1,3 @@
 ---
 openio_kibana_version: "7.x"
-openio_kibana_servicename: "kibana-{{ openio_kibana_serviceid }}"
-
-openio_kibana_sysconfig_dir: "/etc/oio/sds/{{ openio_kibana_namespace }}/{{ openio_kibana_servicename }}"
-openio_kibana_pid_directory: "/run/oio/sds/{{ openio_kibana_namespace }}"
-openio_kibana_log_dir: "/var/log/oio/sds/{{ openio_kibana_namespace }}/{{ openio_kibana_servicename }}"
-
-openio_kibana_url: "http://{{ openio_kibana_bind_address }}:{{ openio_kibana_bind_port }}"
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION