### PR TITLE
BUGFIX/MINOR(kibana): fix `openio_bind_mgmt_address` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An Ansible role for install kibana. Specifically, the responsibilities of this r
 | :---       | :---    | :---             |
 | `openio_kibana_namespace` | `"{{ namespace \| d('OPENIO') }}"` | OpenIO Namespace |
 | `openio_kibana_maintenance_mode` | `"{{ openio_maintenance_mode \| d(false) }}"` | Maintenance mode |
-| `openio_kibana_bind_address` | `"{{ openio_mgmt_bind_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
+| `openio_kibana_bind_address` | `"{{ openio_bind_mgmt_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
 | `openio_kibana_bind_port` | `6911` | HTTP Binding port |
 | `openio_kibana_url` | `"http://{{ openio_kibana_bind_address }}:{{ openio_kibana_bind_port}}"` | URL to access kibana |
 | `openio_kibana_elasticsearch_group` | `elasticsearch` | Elasticsearch group in the inventory |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openio_kibana_namespace: "{{ namespace | d('OPENIO') }}"
 openio_kibana_maintenance_mode: "{{ openio_maintenance_mode | d(false) }}"
 
-openio_kibana_bind_address: "{{ openio_mgmt_bind_address | d(ansible_default_ipv4.address) }}"
+openio_kibana_bind_address: "{{ openio_bind_mgmt_address | d(ansible_default_ipv4.address) }}"
 openio_kibana_bind_port: 6911
 
 openio_kibana_elasticsearch_group: elasticsearch


### PR DESCRIPTION
 ##### SUMMARY
`openio_bind_mgmt_address` instead of `openio_mgmt_bind_address`

 ##### IMPACT
#Describe the impact of the change (N/A for no impact)
N/A

 ##### ADDITIONAL INFORMATION