### PR TITLE
CHANGE(kibana): remove `oio-` prefix to service_type

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_role:
     name: openio-service
   vars:
-    openio_service_type: "oio-kibana"
+    openio_service_type: "kibana"
     openio_service_namespace: "{{ openio_kibana_namespace }}"
     openio_service_maintenance_mode: "{{ openio_kibana_maintenance_mode }}"
     openio_service_packages:


### PR DESCRIPTION
 ##### SUMMARY
no need to have `oio-` in front of service name for monitoring

 ##### IMPACT
service name and path changes

 ##### ADDITIONAL INFORMATION